### PR TITLE
fix for check on ''oxAuthGrantType'

### DIFF
--- a/static/scripts/import3031.py
+++ b/static/scripts/import3031.py
@@ -807,7 +807,7 @@ class Migration(object):
                 inum_l = inum.split('!0008!')
                 #custom clients has three quads
                 if inum_l[1].count('.') > 2:
-                    if entry['oxAuthGrantType'] and  not 'client_credentials' in entry['oxAuthGrantType']:
+                    if 'oxAuthGrantType' in entry and not 'client_credentials' in entry['oxAuthGrantType']:
                         logging.debug('Adding client_credentials to oxAuthGrantType of client inum=%s', inum)
                         entry['oxAuthGrantType'].append('client_credentials')
 


### PR DESCRIPTION
The original code crashed on:
```python
if entry['oxAuthGrantType'] ...
```
when there was no `'oxAuthGrantType'` in `entry`.